### PR TITLE
replace panic in unpack() with error handling

### DIFF
--- a/attr.go
+++ b/attr.go
@@ -178,8 +178,9 @@ func (a *Attribute) unpack(tag Tag, value []byte) error {
 		val = Binary(nil)
 
 	default:
-		panic(fmt.Sprintf("(Attribute) uppack(): tag=%s type=%s", tag, tag.Type()))
+		return fmt.Errorf("(Attribute) unpack(): unexpected tag=%s type=%s", tag, tag.Type())
 	}
+
 
 	val, err = val.decode(value)
 


### PR DESCRIPTION
Replaced panic in unpack() with fmt.Errorf() to prevent crashes caused by invalid or unexpected tags, improves fuzzing stability by allowing the fuzzer to continue exploring deeper paths

Fixes #6 